### PR TITLE
bump wasm-pack-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@wasm-tool/wasm-pack-plugin": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@wasm-tool/wasm-pack-plugin/-/wasm-pack-plugin-0.0.5.tgz",
-      "integrity": "sha512-HqeePgwLyOTgyHKHJo8dP4tqgw1C/OT6BkATxkL9bzM2a51y5cOBEPvfZI9pNuXn128t6iEOhP+9UG+9ce0iHQ==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@wasm-tool/wasm-pack-plugin/-/wasm-pack-plugin-0.0.6.tgz",
+      "integrity": "sha512-msx1mmzKJg+xt0FJh6kdtEhr4Nem+iMvWnODbVR75cr6BxLJQOYZ57SZ/7Y+bDQr3fgqnM9ddbdXs7u5l+eSSg==",
       "dev": true,
       "requires": {
         "chalk": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "create-rust-webpack": ".bin/create-rust-webpack.js"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "0.0.5",
+    "@wasm-tool/wasm-pack-plugin": "0.0.6",
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.17.1",
     "webpack-cli": "^3.1.0",


### PR DESCRIPTION
The plugin now uses the `init` subcommand instead of the future `build` one, for compatibility.

cc @nikgraf FYI