### PR TITLE
Update index.js  Fixes cannot find module ../crate/pkg

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,3 +1,3 @@
-import("../crate/pkg").then(module => {
+import("../crate/pkg/rust_webpack").then(module => {
   module.run();
 });


### PR DESCRIPTION
Fixes #62

When run npm start says

Fixes cannot find module ../crate/pkg

webpack-dev-server 3.1.9
webpack: 4.20.2
wasm-pack 0.5.1
cfg-if = "0.1.5"
wasm-bindgen = "0.2.25"