### PR TITLE
Don't enable `wee_alloc` by default

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -37,4 +37,4 @@ features = [
 ]
 
 [features]
-default-features = ["console_error_panic_hook", "wee_alloc"]
+default-features = ["console_error_panic_hook"]


### PR DESCRIPTION
`wee_alloc` requires nightly for wasm, but none of the rest of the toolchain does, so we should not enable the feature by default.

See https://github.com/rustwasm/wee_alloc/issues/57 for details