### PR TITLE
Changed "default-features" to "features" in Cargo.toml

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -37,4 +37,4 @@ features = [
 ]
 
 [features]
-default-features = ["console_error_panic_hook"]
+default = ["console_error_panic_hook"]


### PR DESCRIPTION
Fixed features section to make ```console_error_panic_hook``` be enabled by default .  