### PR TITLE
Fix the license identifier to conform to SPDX license expression syntax version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "create-rust-webpack",
   "version": "0.1.5",
   "repository": "https://github.com/rustwasm/rust-webpack-template",
-  "license": "Apache-2.0/MIT",
+  "license": "(MIT OR Apache-2.0)",
   "scripts": {
     "start": "webpack-dev-server -d",
     "build": "webpack"


### PR DESCRIPTION
Updating the license identifier in package.json to avoid the warning from NPM CLI
      `npm WARN create-rust-webpack@0.1.5 license should be a valid SPDX license expression` (https://docs.npmjs.com/files/package.json#license)