### PR TITLE
Note that WasmPackPlugin defaults to "dev" profile

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,9 @@ module.exports = {
     }),
 
     new WasmPackPlugin({
-      crateDirectory: path.resolve(__dirname, "crate")
+      crateDirectory: path.resolve(__dirname, "crate"),
+      // WasmPackPlugin defaults to compiling in "dev" profile. To change that, use forceMode: 'release':
+      // forceMode: 'release'
     }),
   ]
 };


### PR DESCRIPTION
Modify the webpack.config.js to point out that the crate will be compiled in "dev" profile by default.

References #116.