### PR TITLE
Migrate to the 2018 edition

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -7,6 +7,7 @@ name = "rust-webpack"
 readme = "./README.md"
 repository = "https://github.com/rustwasm/rust-webpack-template"
 version = "0.1.0"
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -1,15 +1,9 @@
-#[macro_use]
-extern crate cfg_if;
-extern crate web_sys;
-extern crate wasm_bindgen;
-
 use wasm_bindgen::prelude::*;
 
-cfg_if! {
+cfg_if::cfg_if! {
     // When the `console_error_panic_hook` feature is enabled, we can call the
     // `set_panic_hook` function to get better error messages if we ever panic.
     if #[cfg(feature = "console_error_panic_hook")] {
-        extern crate console_error_panic_hook;
         use console_error_panic_hook::set_once as set_panic_hook;
     } else {
         #[inline]
@@ -17,11 +11,10 @@ cfg_if! {
     }
 }
 
-cfg_if! {
+cfg_if::cfg_if! {
     // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
     // allocator.
     if #[cfg(feature = "wee_alloc")] {
-        extern crate wee_alloc;
         #[global_allocator]
         static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
     }


### PR DESCRIPTION
No need for `extern crate` imports!