### PR TITLE
Update README to point to new wasm-pack docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,23 @@
 This template is designed for creating monorepo-style Web applications with
 Rust-generated WebAssembly and Webpack without publishing your wasm to NPM.
 
-* Want to create and publish NPM packages with Rust and WebAssembly? [Check out
-  `wasm-pack-template`.](https://github.com/rustwasm/wasm-pack-template)
+[**📚 Read this template tutorial! 📚**][template-docs]
+
+Be sure to check out [other `wasm-pack` tutorials online][tutorials] for other
+templates and usages of `wasm-pack`.
+
+[tutorials]: https://rustwasm.github.io/docs/wasm-pack/tutorials/index.html
+[template-docs]: https://rustwasm.github.io/docs/wasm-pack/tutorials/hybrid-applications-with-webpack/index.html
+
+## 🚴 Using This Template
+
+You can use `npm init` to clone this template:
+
+```sh
+npm init rust-webpack my-app
+```
+
+[Afterwards check out the full documentation for exploring it][template-docs].
 
 ## 🔋 Batteries Included
 
@@ -17,13 +32,3 @@ to WebAssembly and hooking into a Webpack build pipeline.
   `http://localhost:8080`.
 
 * `npm run build` -- Bundle the project (in production mode).
-
-## 🚴 Using This Template
-
-First, [install `wasm-pack`!](https://rustwasm.github.io/wasm-pack/installer/)
-
-Then, use `npm init` to clone this template:
-
-```sh
-npm init rust-webpack my-app
-```


### PR DESCRIPTION
The purpose of this change is to canonicalize the documentation and
exploration of this template into one place, and the current best place
for that is probably the new `wasm-pack` documentation for hybrid
Webpack apps. Let's be sure to point there!