### PR TITLE
Remove the cfg-if dependency

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-cfg-if = "0.1.5"
 wasm-bindgen = "0.2.25"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -1,24 +1,10 @@
 use wasm_bindgen::prelude::*;
 
-cfg_if::cfg_if! {
-    // When the `console_error_panic_hook` feature is enabled, we can call the
-    // `set_panic_hook` function to get better error messages if we ever panic.
-    if #[cfg(feature = "console_error_panic_hook")] {
-        use console_error_panic_hook::set_once as set_panic_hook;
-    } else {
-        #[inline]
-        fn set_panic_hook() {}
-    }
-}
-
-cfg_if::cfg_if! {
-    // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
-    // allocator.
-    if #[cfg(feature = "wee_alloc")] {
-        #[global_allocator]
-        static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-    }
-}
+// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
+// allocator.
+#[cfg(feature = "wee_alloc")]
+#[global_allocator]
+static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 // Called by our JS entry point to run the example.
 #[wasm_bindgen]
@@ -36,4 +22,11 @@ pub fn run() -> Result<(), JsValue> {
     body.append_child(&p)?;
 
     Ok(())
+}
+
+fn set_panic_hook() {
+    // When the `console_error_panic_hook` feature is enabled, we can call the
+    // `set_panic_hook` function to get better error messages if we ever panic.
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
 }


### PR DESCRIPTION
Since the 2018 edition this is less necessary due to the `extern crate`
annotations no longer being needed. With only single statements being
configured out this can be a bit simpler in the template, and there's
less to explain now!