### PR TITLE
Bump the versions of the wasm-pack-plugin

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -8,11 +8,11 @@
     "test": "cargo test && wasm-pack test --headless"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "^0.4.2",
+    "@wasm-tool/wasm-pack-plugin": "^1.1.0",
     "copy-webpack-plugin": "^5.0.3",
-    "webpack": "^4.33.0",
+    "webpack": "^4.42.0",
     "webpack-cli": "^3.3.3",
     "webpack-dev-server": "^3.7.1",
-    "rimraf": "^2.6.3"
+    "rimraf": "^3.0.0"
   }
 }

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -23,7 +23,6 @@ module.exports = {
 
     new WasmPackPlugin({
       crateDirectory: __dirname,
-      extraArgs: "--out-name index"
     }),
   ]
 };


### PR DESCRIPTION
There is no need to specify `extraArgs` anymore, otherwise this works perfectly fine.