### PR TITLE
replace wasm-pack test --headless to --node

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "rimraf dist pkg && webpack",
     "start": "rimraf dist pkg && webpack-dev-server --open -d",
-    "test": "cargo test && wasm-pack test --headless"
+    "test": "cargo test && wasm-pack test --node"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "^1.1.0",


### PR DESCRIPTION
--headless option is not available when running wasp-pack test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustwasm/rust-webpack-template/166)
<!-- Reviewable:end -->
