### PR TITLE
Update template index to run "Hello world!"

### DIFF
--- a/template/js/index.js
+++ b/template/js/index.js
@@ -1,1 +1,5 @@
-import("../pkg/index.js").catch(console.error);
+import("../pkg/index.js")
+  .then((module) => {
+    module.main_js();
+  })
+  .catch(console.error);


### PR DESCRIPTION
The current implementation doesn't seem to run the function that was exported from Rust, `main_js()`.
At first, I thought this was intentional, but the [current docs](https://github.com/rustwasm/wasm-pack/blob/master/docs/src/tutorials/hybrid-applications-with-webpack/using-your-library.md) which are out of date and say that a `run()` function should be here.
I'll add a link to my change to the docs here shortly.