### PR TITLE
Add rlib to crate-type in Cargo.toml

### DIFF
--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 edition = "2018"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [profile.release]
 # This makes the compiled code faster and smaller, but it makes compiling slower,


### PR DESCRIPTION
I've been learning wasm by [game of life tutorial](https://rustwasm.github.io/docs/book/) recently. The difference from the tutorial is that I use `rust-webpack-template` (this repo) instead of `wasm-pack-template` (https://github.com/rustwasm/wasm-pack-template).

When I entered the `Testing life` section, I got a problem; I couldn't import things from `src/lib.rs` in `tests/app.rs`. For example, say `src/lib.rs` has the following content:

```rust
pub fn foo() -> i32 {
    42
}
```

and `tests/app.rs` tries to import `foo` like this:

```rust
use my_wasm_project::foo;

#[test]
...
```

then `use my_wasm_project::foo;` flags an error that says "unresolved import `my_wasm_project`".

I was confused at first, and I tried to look into it, I found [this comment in a cargo's issue](https://github.com/rust-lang/cargo/issues/6659#issuecomment-463335095).  Then adding `rlib` to Cargo.toml, it all works fine.

Moreover, Cargo.toml in `wasm-pack-template` actually specifies `rlib`. ref: https://github.com/rustwasm/wasm-pack-template/blob/master/Cargo.toml#L8

I'd be happy to have this PR merged. Thank you :)

