### PR TITLE
Upgrade dependencies (fixes errors with modern Node)

### DIFF
--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["You <you@example.com>"]
 categories = ["wasm"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]
@@ -30,22 +30,18 @@ wasm-bindgen = "0.2.45"
 # allocator, so it's not enabled by default.
 wee_alloc = { version = "0.4.2", optional = true }
 
+# The `console_error_panic_hook` crate provides better debugging of panics by
+# logging them with `console.error`.
+console_error_panic_hook = "0.1.5"
+
 # The `web-sys` crate allows you to interact with the various browser APIs,
 # like the DOM.
 [dependencies.web-sys]
 version = "0.3.22"
 features = ["console"]
 
-# The `console_error_panic_hook` crate provides better debugging of panics by
-# logging them with `console.error`. This is great for development, but requires
-# all the `std::fmt` and `std::panicking` infrastructure, so it's only enabled
-# in debug mode.
-[target."cfg(debug_assertions)".dependencies]
-console_error_panic_hook = "0.1.5"
-
 # These crates are used for running unit tests.
 [dev-dependencies]
-wasm-bindgen-test = "0.2.45"
-futures = "0.1.27"
+wasm-bindgen-test = "0.3.34"
 js-sys = "0.3.22"
-wasm-bindgen-futures = "0.3.22"
+wasm-bindgen-futures = "0.4.34"

--- a/template/package.json
+++ b/template/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "rimraf dist pkg && webpack",
     "start": "rimraf dist pkg && webpack serve --open",
-    "test": "cargo test && wasm-pack test --node --headless"
+    "test": "cargo test && wasm-pack test --headless"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "^1.7.0",

--- a/template/package.json
+++ b/template/package.json
@@ -4,15 +4,15 @@
   "version": "0.1.0",
   "scripts": {
     "build": "rimraf dist pkg && webpack",
-    "start": "rimraf dist pkg && webpack-dev-server --open -d",
-    "test": "cargo test && wasm-pack test --headless"
+    "start": "rimraf dist pkg && webpack serve --open",
+    "test": "cargo test && wasm-pack test --node --headless"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "^1.1.0",
-    "copy-webpack-plugin": "^5.0.3",
-    "webpack": "^4.42.0",
-    "webpack-cli": "^3.3.3",
-    "webpack-dev-server": "^3.7.1",
-    "rimraf": "^3.0.0"
+    "@wasm-tool/wasm-pack-plugin": "^1.7.0",
+    "copy-webpack-plugin": "^11.0.0",
+    "rimraf": "^5.0.0",
+    "webpack": "^5.54.0",
+    "webpack-cli": "^5.1.0",
+    "webpack-dev-server": "^4.15.0"
   }
 }

--- a/template/tests/app.rs
+++ b/template/tests/app.rs
@@ -1,10 +1,8 @@
-use wasm_bindgen_test::{wasm_bindgen_test_configure, wasm_bindgen_test};
-use futures::prelude::*;
 use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::JsFuture;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
 wasm_bindgen_test_configure!(run_in_browser);
-
 
 // This runs a unit test in native Rust, so it can only use Rust APIs.
 #[test]
@@ -12,24 +10,19 @@ fn rust_test() {
     assert_eq!(1, 1);
 }
 
-
 // This runs a unit test in the browser, so it can use browser APIs.
 #[wasm_bindgen_test]
 fn web_test() {
     assert_eq!(1, 1);
 }
 
-
-// This runs a unit test in the browser, and in addition it supports asynchronous Future APIs.
-#[wasm_bindgen_test(async)]
-fn async_test() -> impl Future<Item = (), Error = JsValue> {
-    // Creates a JavaScript Promise which will asynchronously resolve with the value 42.
+// This runs a unit test in the browser, and in addition it supports asynchronous functions
+#[wasm_bindgen_test]
+async fn my_async_test() {
+    // Create a promise that is ready on the next tick of the micro task queue.
     let promise = js_sys::Promise::resolve(&JsValue::from(42));
 
-    // Converts that Promise into a Future.
-    // The unit test will wait for the Future to resolve.
-    JsFuture::from(promise)
-        .map(|x| {
-            assert_eq!(x, 42);
-        })
+    // Convert that promise into a future and make the test wait on it.
+    let x = JsFuture::from(promise).await.unwrap();
+    assert_eq!(x, 42);
 }

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -5,24 +5,26 @@ const WasmPackPlugin = require("@wasm-tool/wasm-pack-plugin");
 const dist = path.resolve(__dirname, "dist");
 
 module.exports = {
-  mode: "production",
+  mode: "development",
+  experiments: {
+    futureDefaults: true,
+  },
   entry: {
-    index: "./js/index.js"
+    index: "./js/index.js",
   },
   output: {
     path: dist,
-    filename: "[name].js"
+    filename: "[name].js",
   },
   devServer: {
-    contentBase: dist,
+    static: dist,
   },
   plugins: [
-    new CopyPlugin([
-      path.resolve(__dirname, "static")
-    ]),
-
+    new CopyPlugin({
+      patterns: [path.resolve(__dirname, "static")],
+    }),
     new WasmPackPlugin({
       crateDirectory: __dirname,
     }),
-  ]
+  ],
 };

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -7,7 +7,7 @@ const dist = path.resolve(__dirname, "dist");
 module.exports = {
   mode: "development",
   experiments: {
-    futureDefaults: true,
+    asyncWebAssembly: true,
   },
   entry: {
     index: "./js/index.js",


### PR DESCRIPTION
I've found that the current template does not work with Node 17+, due to [this](https://github.com/webpack/webpack/issues/14532) break. A fix for that is available in more recent versions of Webpack, so bumping the dependency version is a valid fix for the issue. Of course, since the Webpack upgrade is itself breaking, I've had to upgrade other dependencies as well, as well as modify some configuration files.

Since most dependencies were very stale and I was getting a lot of warnings for deprecations and vulnerabilities, I decided to go for a full upgrade of everything. This includes both JS and Rust dependencies, and even the Rust edition, which I bumped to 2021. Small changes to sample code were needed. As a bonus, I got rid of the dependency on the `futures` crate, as native futures are now supported.

One side change I did after going over warnings was to remove the `[target."cfg(debug_assertions)".dependencies]` block. As reported [here](https://github.com/rust-lang/cargo/issues/7634) (and documented [here](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies)) it doesn't actually do anything, just gets silently ignored. Removing that bug makes sense as it's something that is now reported with newer Rust.