### PR TITLE
Update template to use webpack v5.98.0 to support Rust 1.82+

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -4,15 +4,15 @@
   "version": "0.1.0",
   "scripts": {
     "build": "rimraf dist pkg && webpack",
-    "start": "rimraf dist pkg && webpack-dev-server --open -d",
+    "start": "rimraf dist pkg && webpack serve --open --mode development --devtool eval-cheap-module-source-map",
     "test": "cargo test && wasm-pack test --headless"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "^1.1.0",
-    "copy-webpack-plugin": "^5.0.3",
-    "webpack": "^4.42.0",
-    "webpack-cli": "^3.3.3",
-    "webpack-dev-server": "^3.7.1",
+    "copy-webpack-plugin": "^12.0.2",
+    "webpack": "^5.98.0",
+    "webpack-cli": "^6.0.1",
+    "webpack-dev-server": "^5.2.0",
     "rimraf": "^3.0.0"
   }
 }

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -14,15 +14,20 @@ module.exports = {
     filename: "[name].js"
   },
   devServer: {
-    contentBase: dist,
+    static: dist,
   },
   plugins: [
-    new CopyPlugin([
-      path.resolve(__dirname, "static")
-    ]),
+    new CopyPlugin({
+      patterns: [
+        path.resolve(__dirname, "static")
+      ],
+    }),
 
     new WasmPackPlugin({
       crateDirectory: __dirname,
     }),
-  ]
+  ],
+  experiments: {
+    asyncWebAssembly: true,
+  },
 };


### PR DESCRIPTION
Starting from [Rust 1.82.0](https://releases.rs/docs/1.82.0/) (released 2024-10-17) [Reference types](https://webassembly.github.io/reference-types/core/syntax/types.html#reference-types) are enabled for WebAssembly target by default.

Reference types are not supported by older webpack versions, see issue #191 for more details. Support for WebAssembly Reference types was added in [webpack v5.97.0](https://github.com/webpack/webpack/releases/tag/v5.97.0).

